### PR TITLE
Added import for `ctime` to make `clock()` work.

### DIFF
--- a/include/openbabel/obutil.h
+++ b/include/openbabel/obutil.h
@@ -44,6 +44,7 @@ GNU General Public License for more details.
 
 // For backwards compatibility. Will be removed in the future
 #include <openbabel/rand.h>
+#include <ctime>
 
 namespace OpenBabel
 {


### PR DESCRIPTION
Won't compile on newer Ubuntu vesions due to missing import. This patch fixes it.